### PR TITLE
feat: read receipt on chat message

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,25 @@
 [![License: MIT][license_badge]][license_link]
 [![Powered by Dart Frog](https://img.shields.io/endpoint?url=https://tinyurl.com/dartfrog-badge)](https://dartfrog.vgv.dev)
 
-An example application built with dart_frog
-This is a sample application that demonstrates how to use the dart_frog package to build a backend application.
+# Description
+This is a simple REST backend.
+Think of it as a template for building a REST backend in Dart.
+
+
+## Features
+##### ✅ Authentication (*Login, Register*)
+##### ✅ User Profile (*Avatar, Bio*)
+##### ✅ Profile (*Follow, Unfollow*)
+##### 🚧 Posts (*Post, Like, Comment*)
+##### ✅ Chat (*Send, Receive, Send Image*)
+##### ✅ ChatMessage Read Receipt (*Delivered, Read*)
 
 ## Docs
 
 - [Pull Request Template](/docs/pull_request_template.md)
 
 # Author
-- [Saint Rikky](https://github.com/MikkyBoy357)
+- [St.](https://github.com/MikkyBoy357)
 
 [license_badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [license_link]: https://opensource.org/licenses/MIT

--- a/lib/common/models/messaging/chat_message.dart
+++ b/lib/common/models/messaging/chat_message.dart
@@ -1,3 +1,5 @@
+import 'package:cats_backend/common/common.dart';
+import 'package:cats_backend/common/models/messaging/read_receipt.dart';
 import 'package:mongo_dart/mongo_dart.dart';
 
 enum MessageType { text, media, event }
@@ -10,6 +12,7 @@ class ChatMessage {
   final String message;
   final MessageType messageType;
   final String? mediaUrl;
+  final ReadReceipt readReceipt;
 
   ChatMessage({
     required this.id,
@@ -19,6 +22,7 @@ class ChatMessage {
     required this.message,
     this.messageType = MessageType.text,
     this.mediaUrl,
+    required this.readReceipt,
   });
 
   factory ChatMessage.fromJson(Map<String, dynamic> json) {
@@ -34,6 +38,16 @@ class ChatMessage {
         (e) => e.name == json['messageType'],
       ),
       mediaUrl: json['mediaUrl'] as String?,
+      readReceipt: () {
+        /// Some messages were sent before the read receipt feature was added
+        /// So we need to check if the read receipt is null and return an empty
+        final res = json['readReceipt'];
+        return res == null
+            ? ReadReceipt.empty()
+            : ReadReceipt.fromJson(
+                res as Map<String, dynamic>,
+              );
+      }(),
     );
   }
 
@@ -46,6 +60,7 @@ class ChatMessage {
       'message': message,
       'messageType': messageType.name,
       'mediaUrl': mediaUrl,
+      'readReceipt': readReceipt.toJson(),
     };
   }
 }

--- a/lib/common/models/messaging/messaging.dart
+++ b/lib/common/models/messaging/messaging.dart
@@ -1,2 +1,4 @@
 export 'chat.dart';
 export 'chat_message.dart';
+export 'read_receipt.dart';
+export 'receipt_payload.dart';

--- a/lib/common/models/messaging/read_receipt.dart
+++ b/lib/common/models/messaging/read_receipt.dart
@@ -1,0 +1,45 @@
+import 'package:mongo_dart/mongo_dart.dart';
+
+enum ReadStatus { delivered, read }
+
+class ReadReceipt {
+  final List<ObjectId> deliveredTo;
+  final List<ObjectId> readBy;
+
+  ReadReceipt({
+    required this.deliveredTo,
+    required this.readBy,
+  });
+
+  factory ReadReceipt.fromJson(Map<String, dynamic> json) {
+    return ReadReceipt(
+      deliveredTo:
+          (json['deliveredTo'] as List).map((e) => e as ObjectId).toList(),
+      readBy: (json['readBy'] as List).map((e) => e as ObjectId).toList(),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'deliveredTo': deliveredTo.map((e) => e).toList(),
+      'readBy': readBy.map((e) => e).toList(),
+    };
+  }
+
+  ReadReceipt copyWith({
+    List<ObjectId>? deliveredTo,
+    List<ObjectId>? readBy,
+  }) {
+    return ReadReceipt(
+      deliveredTo: deliveredTo ?? this.deliveredTo,
+      readBy: readBy ?? this.readBy,
+    );
+  }
+
+  @override
+  String toString() => '{ deliveredTo: $deliveredTo, readBy: $readBy }';
+
+  factory ReadReceipt.empty() {
+    return ReadReceipt(deliveredTo: [], readBy: []);
+  }
+}

--- a/lib/common/models/messaging/receipt_payload.dart
+++ b/lib/common/models/messaging/receipt_payload.dart
@@ -1,0 +1,30 @@
+import 'package:cats_backend/common/models/models.dart';
+
+/// This is what a payload clients emit to the socket
+/// to indicate that they have read a message
+
+class ReceiptPayload {
+  final String messageId;
+  final ReadStatus status;
+
+  ReceiptPayload({
+    required this.messageId,
+    required this.status,
+  });
+
+  factory ReceiptPayload.fromJson(Map<String, dynamic> json) {
+    return ReceiptPayload(
+      messageId: json['messageId'] as String,
+      status: ReadStatus.values.firstWhere(
+        (e) => e.name == json['status'],
+      ),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'messageId': messageId,
+      'status': status.name,
+    };
+  }
+}

--- a/lib/common/models/ws/wsEventMessage.dart
+++ b/lib/common/models/ws/wsEventMessage.dart
@@ -1,11 +1,11 @@
 import 'dart:convert';
 
-enum WsEventType { message, typing, read, connect }
+enum WsEventType { message, typing, receipt, connect }
 
 class WsEventMessage {
   final String? id;
   final WsEventType eventType;
-  final String? message;
+  final dynamic message;
   final String? senderId;
 
   WsEventMessage({
@@ -21,7 +21,7 @@ class WsEventMessage {
       eventType: WsEventType.values.firstWhere((e) {
         return e.name.toLowerCase() == json['eventType'];
       }),
-      message: json['message'] as String?,
+      message: json['message'],
       senderId: json['senderId'] as String?,
     );
   }
@@ -38,7 +38,7 @@ class WsEventMessage {
   WsEventMessage copyWith({
     String? id,
     WsEventType? eventType,
-    String? message,
+    dynamic message,
     String? senderId,
   }) {
     return WsEventMessage(

--- a/lib/common/print_color.dart
+++ b/lib/common/print_color.dart
@@ -2,6 +2,10 @@ void printRed(String message) {
   print('\x1B[31m$message\x1B[0m');
 }
 
+void printYellow(String message) {
+  print('\x1B[33m$message\x1B[0m');
+}
+
 void printGreen(String message) {
   print('\x1B[32m$message\x1B[0m');
 }

--- a/routes/api/chats/[chatId]/index.dart
+++ b/routes/api/chats/[chatId]/index.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:cats_backend/data/repositories/repositories.dart';
 import 'package:cats_backend/data/request_handlers/request_handlers.dart';
 import 'package:cats_backend/helpers/helpers.dart';
@@ -18,6 +20,11 @@ Future<Response> onRequest(RequestContext context, String id) async {
 
   final saint = authValidationResponse.user!;
 
+  final body = await context.request.body();
+  print('LeBody ==> $body');
+  final bodyJson = jsonDecode(body) as Map<String, dynamic>;
+  print('LeJSON ==> $bodyJson');
+
   final chatId = ObjectId.tryParse(id);
   if (chatId == null) {
     return Response.json(body: 'Error: Cannot Parse Invalid Chat ID.');
@@ -26,7 +33,6 @@ Future<Response> onRequest(RequestContext context, String id) async {
   final chatRepository = ChatRepository(database: mongoDbService.database);
   final request = context.request;
   final method = request.method;
-  final queryParams = request.uri.queryParameters;
   final handler = ChatRequestHandlerImpl(chatRepository: chatRepository);
 
   final currentChat = await chatRepository.getChatById(chatId: chatId);
@@ -64,6 +70,4 @@ Future<Response> onRequest(RequestContext context, String id) async {
         ),
       ),
   };
-
-  return Response.json(body: 'Chats Endpoint not yet implemented.');
 }


### PR DESCRIPTION
## Describe your changes briefly

Read receipts on ChatMessage

### Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have tested using 2 or more accounts
- [ ] I created tests for necessary files
- [x] I added videos and/or images if this PR changed the routes or app behavior in a way the user would notice

### Describe your changes in detail

- Mark add user name to the deliverTo/readBy list of a chatMessage

### How to test

- Client can emit a message with type `receipt` with payload containing the ChatMessageId so update read receipts for that chat message in a chat

https://github.com/user-attachments/assets/032e6e8b-8eae-4c11-a1e5-207dff4fcb60

